### PR TITLE
style: add clang-tidy to keep names consistent

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -15,10 +15,10 @@ CheckOptions:
   readability-identifier-naming.PrivateMemberCase: camelBack
   readability-identifier-naming.PrivateMemberPrefix: m_
   # statics
-  readability-identifier-naming.StaticVariableCase: camelBack
-  readability-identifier-naming.StaticVariablePrefix: s_
-  readability-identifier-naming.ClassMemberCase: camelBack
-  readability-identifier-naming.ClassMemberPrefix: s_
+  readability-identifier-naming.StaticVariableCase: CamelCase
+  readability-identifier-naming.StaticVariablePrefix: s
+  readability-identifier-naming.ClassMemberCase: CamelCase
+  readability-identifier-naming.ClassMemberPrefix: s
   # constants
   readability-identifier-naming.GlobalConstantCase: UPPER_CASE
   # globals


### PR DESCRIPTION
This will allow for IDEs to enforce the naming system, and we can add a GitHub action to verify that the naming system is being followed.

This `.clang-tidy` enforces:
```cpp
constexpr int CONST_GLOBAL_VAR = 0;
int gGlobalVar = 0;

class Something {
    static constexpr int CONST_CLASS_MEMBER = 0;
    static int sStaticClassMember;

public:
    int mPublicField;
protected:
    int mProtectedField;
private:
    int mPrivateField;
}
```